### PR TITLE
Caption size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - []  ([#](https://github.com/airbnb/react-dates/pull/))
 -->
 
+##18.2.13
+
+- [Modify] - Changing mini caption size
+
 ##18.2.12
 
 - [Modify] - adding mini sized range selector

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lyric-travel/react-dates",
-  "version": "18.2.12",
+  "version": "18.2.13",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {

--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -266,7 +266,7 @@ export default {
       },
       mini: {
         size: 22,
-        captionSize: 28,
+        captionSize: 24,
         dayLabel: 15,
       },
     },


### PR DESCRIPTION
Changing caption size because the website uses a different font family than this project's storybook. 

Because of this the caption size in storybook _looked_ good, but in practice it was too big.

Before:
![screen shot 2018-12-18 at 6 34 05 pm](https://user-images.githubusercontent.com/5024454/50195402-bf38f400-02f3-11e9-9b52-d1b9ac54d796.png)

After:
![screen shot 2018-12-18 at 6 34 29 pm](https://user-images.githubusercontent.com/5024454/50195406-c4963e80-02f3-11e9-81d3-04b176189eb2.png)
