### PR TITLE
Fix mobile vertical scroll display, when date is selected and user re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 <!--
 - []  ([#](https://github.com/airbnb/react-dates/pull/))
 -->
+## 18.4.3
+- [Modify] Display correct range of month wile using DatePickerRangeController with orientation landscape.
+-
 ## 18.4.2
 - [Modify] Modify styles
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lyric-travel/react-dates",
-  "version": "18.4.2",
+  "version": "18.4.3",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -61,6 +61,8 @@ const propTypes = forbidExtraProps({
   transitionDuration: nonNegativeInteger,
   verticalBorderSpacing: nonNegativeInteger,
   size: PropTypes.string,
+  minDate: momentPropTypes.momentObj,
+  maxDate: momentPropTypes.momentObj,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -96,6 +98,9 @@ const defaultProps = {
   isRTL: false,
   transitionDuration: 200,
   verticalBorderSpacing: undefined,
+  size: undefined,
+  minDate: undefined,
+  maxDate: undefined,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -121,7 +126,7 @@ class CalendarMonthGrid extends React.PureComponent {
     super(props);
     const withoutTransitionMonths = props.orientation === VERTICAL_SCROLLABLE;
     this.state = {
-      months: getMonths(props.initialMonth, props.numberOfMonths, withoutTransitionMonths),
+      months: getMonths(props.orientation === VERTICAL_SCROLLABLE && props.minDate ? props.minDate : props.initialMonth, props.numberOfMonths, withoutTransitionMonths),
     };
 
     this.isTransitionEndSupported = isTransitionEndSupported();

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -72,6 +72,8 @@ const propTypes = forbidExtraProps({
   verticalBorderSpacing: nonNegativeInteger,
   horizontalMonthPadding: nonNegativeInteger,
   size: PropTypes.string,
+  minDate: PropTypes.any,
+  maxDate: PropTypes.any,
 
   // navigation props
   disablePrev: PropTypes.bool,
@@ -132,6 +134,9 @@ export const defaultProps = {
   transitionDuration: undefined,
   verticalBorderSpacing: undefined,
   horizontalMonthPadding: 13,
+  size: undefined,
+  minDate: undefined,
+  maxDate: undefined,
 
   // navigation props
   disablePrev: false,
@@ -946,6 +951,8 @@ class DayPicker extends React.PureComponent {
       verticalBorderSpacing,
       horizontalMonthPadding,
       size,
+      minDate,
+      maxDate,
     } = this.props;
 
     const { reactDates: { spacing: { dayPickerHorizontalPadding } } } = theme;
@@ -1110,6 +1117,8 @@ class DayPicker extends React.PureComponent {
                   verticalBorderSpacing={verticalBorderSpacing}
                   horizontalMonthPadding={horizontalMonthPadding}
                   size={size}
+                  minDate={minDate}
+                  maxDate={maxDate}
                 />
                 {verticalScrollable && this.renderNavigation()}
               </div>
@@ -1146,7 +1155,7 @@ export default withStyles(({
     noScrollBarOnVerticalScrollable,
     spacing,
     zIndex,
-    },
+  },
 }) => ({
   DayPicker: {
     background: color.background,

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -843,6 +843,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       enableOutsideDays,
       orientation,
       startDate,
+      minDate,
     } = nextProps;
     const initialVisibleMonthThunk = initialVisibleMonth || (
       startDate ? () => startDate : () => this.today
@@ -850,7 +851,7 @@ export default class DayPickerRangeController extends React.PureComponent {
     const currentMonth = initialVisibleMonthThunk();
     const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
     const visibleDays = this.getModifiers(getVisibleDays(
-      currentMonth,
+      orientation === VERTICAL_SCROLLABLE && minDate ? minDate : currentMonth,
       numberOfMonths,
       enableOutsideDays,
       withoutTransitionMonths,
@@ -1123,6 +1124,8 @@ export default class DayPickerRangeController extends React.PureComponent {
       verticalBorderSpacing,
       horizontalMonthPadding,
       size,
+      minDate,
+      maxDate,
     } = this.props;
 
     const {
@@ -1182,6 +1185,8 @@ export default class DayPickerRangeController extends React.PureComponent {
         transitionDuration={transitionDuration}
         horizontalMonthPadding={horizontalMonthPadding}
         size={size}
+        minDate={minDate}
+        maxDate={maxDate}
       />
     );
   }


### PR DESCRIPTION
https://lyric-hospitality.atlassian.net/browse/GDC-683

Functionality to display range of minDate and maxDate was not developed with verticalScroll mode. 
By default it used selected date and added number of month to that date.

I added few changes in order to make this work.